### PR TITLE
Update default gemini model

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,7 @@ const entrypoint = meow(
       model: {
         type: "string",
         shortFlag: "m",
-        default: "gemini-2.5-flash",
+        default: "gemini-2.5-pro",
       },
       concurrency: {
         type: "number",


### PR DESCRIPTION
Usage help states gemini-2.5-pro used, but actually uses gemini-2.5-flash